### PR TITLE
修复nodebb更新后插件无法载入的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,4 @@ pip-log.txt
 
 sftp-config.json
 node_modules/
+package-lock.json

--- a/lib.js
+++ b/lib.js
@@ -59,7 +59,7 @@ function uuid(len, radix) {
 function Generate(settings) {
   var W = settings.width;
   var H = settings.height;
-  var canvas = createCanvas(W, H);
+  var canvas = Canvas.createCanvas(W, H);
   var ctx = canvas.getContext('2d');
   var items = uuid(settings.leng, 16).split('');
   var vcode = '';

--- a/lib.js
+++ b/lib.js
@@ -59,7 +59,7 @@ function uuid(len, radix) {
 function Generate(settings) {
   var W = settings.width;
   var H = settings.height;
-  var canvas = new Canvas(W, H);
+  var canvas = createCanvas(W, H);
   var ctx = canvas.getContext('2d');
   var items = uuid(settings.leng, 16).split('');
   var vcode = '';

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "canvas": "^1.6.5",
+    "canvas": "latest",
     "mobile-detect":"1.3.6"
   },
   "nbbpm": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "bugs": {
     "url": "https://github.com/a632079/nodebb-plugin-registration-verify/issues"
   },
-  
   "repository": {
     "type": "git",
     "url": "https://github.com/a632079/nodebb-plugin-registration-verify"
@@ -27,7 +26,7 @@
   "license": "ISC",
   "dependencies": {
     "canvas": "latest",
-    "mobile-detect":"1.3.6"
+    "mobile-detect": "1.3.6"
   },
   "nbbpm": {
     "compatibility": "^1.5.0"


### PR DESCRIPTION
此插件引用了canvas库，但是1.6.x版本一直安装失败，应该是和新版本nodejs版本不兼容的问题。
现在把canvas库更新到最新版本，可以正常使用了。